### PR TITLE
Fix #4

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -120,14 +120,16 @@ void Config::parseConfig(std::istream& file)
 			if(procman->getProgram()) {
 				throw std::runtime_error("Program already set!");
 			}
-			if(mProgram.command && mProgram.enabled)
-				procman->setProgram(new Process(logger, mProgram.command, true));
+			if(mProgram.command)
+				procman->setProgram(new Process(logger, mProgram.command, true,
+							mProgram.enabled));
 		}
 		else if(key == "test")
 		{
-			this->parseCommand(it->second, mTest);
-			if(mTest.command && mTest.enabled)
-				procman->addProcess(new Process(logger, mTest.command, true));
+			this->parseCommand(*it, mTest);
+			if(mTest.command)
+				procman->addProcess(new Process(logger, mTest.command, true,
+							mTest.enabled));
 		}
 		else if(key == "compile")
 		{
@@ -135,8 +137,9 @@ void Config::parseConfig(std::istream& file)
 			if(procman->getBuildStep()) {
 				throw std::runtime_error("BuildStage already set!");
 			}
-			if(mCompile.command && mCompile.enabled)
-				procman->setBuilder(new Process(logger, mCompile.command, true));
+			if(mCompile.command)
+				procman->setBuilder(new Process(logger, mCompile.command, true,
+							mCompile.enabled));
 		}
 		else
 		{

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -43,21 +43,22 @@
 #include <cstring>
 #include <sys/wait.h>
 
-Process::Process(iLogger* logger, const std::string &command, bool in_path) :
+Process::Process(iLogger* logger, const std::string &command, bool in_path,
+		bool enabled) :
 	mProc(0),
 	mSearchInPath(in_path),
 	mGeneratedCommand(true),
-	mEnabled(true),
+	mEnabled(enabled),
 	logger(logger)
 {
 	mCommand = Util::parseCommand(command);
 }
 
-Process::Process(iLogger* logger, char** command, bool in_path) :
+Process::Process(iLogger* logger, char** command, bool in_path, bool enabled) :
 	mProc(0),
 	mSearchInPath(in_path),
 	mGeneratedCommand(false),
-	mEnabled(true),
+	mEnabled(enabled),
 	mCommand(command),
 	logger(logger)
 {
@@ -76,6 +77,8 @@ Process::~Process()
 
 bool Process::run()
 {
+	if(mCommand == NULL || !mEnabled)
+		return true;
 	mProc = fork();
 	if(mProc == -1)
 	{
@@ -131,6 +134,8 @@ bool Process::run()
 }
 bool Process::runAndWait()
 {
+	if(mCommand == NULL || !mEnabled)
+		return true;
 	if(!this->run())
 		return false;
 	int status = 0;

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -50,8 +50,8 @@ class Process
 		iLogger* logger;
 	public:
 		~Process();
-		Process(iLogger*, const std::string &command, bool in_path);
-		Process(iLogger*, char** command, bool in_path);
+		Process(iLogger*, const std::string &command, bool in_path, bool enabled);
+		Process(iLogger*, char** command, bool in_path, bool enabled);
 		inline void enable() { mEnabled = true; };
 		inline void disable() { mEnabled = false; };
 		inline bool isEnabled() { return mEnabled; };


### PR DESCRIPTION
This is a fix for GH-4. Renzoku no longer segfaults when the build step is
disabled.